### PR TITLE
chore: add macos for swift analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -118,6 +118,7 @@ jobs:
         name: Build iOS/macOS for Swift analysis
         run: |
           flutter build ios --release --no-codesign
+          flutter build macos
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/codeql.yml` file to include `macos` files for the Swift CodeQL analysis.